### PR TITLE
Update 02-hello-world.mdx

### DIFF
--- a/docs/tutorial/02-hello-world.mdx
+++ b/docs/tutorial/02-hello-world.mdx
@@ -537,7 +537,7 @@ If no object of the specified type is stored under the given path, the function 
 a special type of data that we will cover later)
 
 If there is an object of the specified type at the path, the function returns that object
-and the storage will longer contain an object under the given path.
+and the storage will no longer contain an object under the given path.
 
 The type parameter for the object type to load is contained in `<>`.
 A type argument for the parameter must be provided explicitly, which is `@HelloWorld.HelloAsset` here.
@@ -646,7 +646,7 @@ transaction {
     // result of the borrow could fail, so it is an optional.
     // If the optional is nil,
     // the panic will happen with a descriptive error message
-    let helloReference = capability.borrow()
+    let helloReference = capability!.borrow()
       ?? panic("Could not borrow a reference to the hello capability")
 
     // Call the hello function using the reference


### PR DESCRIPTION
Closes #1357

## Description

I changed let helloReference = capability.borrow() to let helloReference = capability!.borrow() to match the playground and prevent the error unknown member error.
I corrected "and the storage will longer contain an object under the given path." to "and the storage will no longer contain an object under the given path."

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
